### PR TITLE
Feature/GitCheckout

### DIFF
--- a/GitCheckout.ps1
+++ b/GitCheckout.ps1
@@ -5,7 +5,7 @@
 
   Checkout (switch-to) branch.
   If it doesn't exist locally, check "remotes/origin/" by default. You can optionally
-  specify an different remote other than the default.
+  specify a different remote other than the default.
 
   Usage:
     GitCheckout "BranchName"          ; Checkout branch, origin as default

--- a/GitCheckout.ps1
+++ b/GitCheckout.ps1
@@ -1,0 +1,75 @@
+<#
+  Git commandline helpers for PowerShell
+  Author: Damian Suess
+  Revision: 1 - 2020-01-08
+
+  Checkout (switch-to) branch.
+  If it doesn't exist locally, check "remotes/origin/" by default. You can optionally
+  specify an different remote other than the default.
+
+  Usage:
+    GitCheckout "BranchName"          ; Checkout branch, origin as default
+    GitCheckout "BranchName" "origin" ; Pulls current branch from specified remote
+
+  TODO:
+    - Do the work
+    - Fetch if it doesn't find branch on first try
+    - Check alternative remote
+
+  Change Log:
+    2020-01-08  0.1 - Created
+#>
+
+# git checkout -b feature-MyBranch remotes/origin/feature-MyBranch --
+
+# Commandline Params ---
+param(
+  [parameter(Mandatory=$true)][string] $branch = ""
+  # , [parameter(Mandatory=$false)][string] $remote = "origin"
+);
+
+# Include Files --------
+. "GitHelpers.ps1";
+
+# Our code -------------
+[string] $branchName = GitCurrentBranch;
+if ($branchName.Trim() -eq $branch.Trim())
+{
+  Write-Host "DevOps: Already on that branch." -ForegroundColor Yellow;
+  exit;
+}
+
+# Attempt to get it locally
+GitCheckout($branch);
+
+$branchName = GitCurrentBranch;
+if ($branchName.Trim() -eq $branch.Trim())
+{
+  Write-Host "DevOps: Switched to $branch." -ForegroundColor Green;
+  exit;
+}
+
+# TODO - If optional remote provided, use it first
+# .. here ..
+
+# Attempt to get it from origin
+Invoke-Expression "git checkout -b $branch remotes/origin/$branch";
+$branchName = GitCurrentBranch;
+
+if ($branchName.Trim() -eq $branch.Trim())
+{
+  Write-Host "DevOps: Switched to $branch from remote." -ForegroundColor Green;
+  exit;
+}
+
+# Fetch and try again from origin
+GitFetch;
+
+Invoke-Expression "git checkout -b $branch remotes/origin/$branch";
+$branchName = GitCurrentBranch;
+
+if ($branchName.Trim() -eq $branch.Trim())
+{
+  Write-Host "DevOps: Switched to $branch from remote after 'fetch'." -ForegroundColor Green;
+  exit;
+}

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,22 @@ _NOTE: You must have a "develop" branch_
 GitSync
 ```
 
+### GitCheckout
+Checks out your branch in the following execution order
+1. Attempt locally
+2. Attempt on ``origin``
+3. Fetch, then try ``origin`` again.
+
+_In the future we will provide the option for a different remote_
+
+#### Usage
+```
+GitCheckout MyBranch
+GitCheckout feature/MyBranch
+GitCheckout "feature/MyBranch"
+```
+
+
 ### GitCommit
 Commits changes with provided message. Optionally ``push``es up branch.
 


### PR DESCRIPTION
Checkout (switch-to) branch.  If it doesn't exist locally, check "remotes/origin/" by default. You can optionally specify a different remote other than the default.