### PR TITLE
Merge feature/GitMergeUnrelatedHistories into develop

### DIFF
--- a/GitHelpers.ps1
+++ b/GitHelpers.ps1
@@ -114,16 +114,24 @@ function GitPrune([bool] $syncPrune)
   }
 }
 
-function GitPull([string] $remote, [string] $branch)
+function GitPull([string] $remote, [string] $branch, [bool] $unrelatedHistories = $false)
 {
   # Example:
-  #   Pull and set tracking - GitPull("origin")("MyBranch")(true);
-  #   Pull with no tracking - GitPull("origin")("MyBranch")(false);
+  #   Pull unrelated history - GitPull("origin")("MyBranch")($true);
   #
-  # Consider adding, [bool] $withTracking=true
-  # git branch --set-upstream-to=origin/<branch> feature-en-InsertCfg-ROI
+  # Consider adding, Pull and set tracking
+  #   PARAM:  [bool] $withTracking=true
+  #   CMD:    git branch --set-upstream-to=origin/<branch> feature-en-InsertCfg-ROI
+  #   Usage:  GitPull("origin")("MyBranch")($false)($true);
 
-  Invoke-Expression "git pull ""${remote}"" ""${branch}""";
+  [string] $cmdEx = "-v ";
+  if ($unrelatedHistories -eq $true)
+  {
+    # "git.exe pull --progress -v --no-rebase --allow-unrelated-histories "origin" master"
+    $cmdEx = "--allow-unrelated-histories ";
+  }
+
+  Invoke-Expression "git pull ${cmdEx}""${remote}"" ""${branch}""";
 }
 
 function GitPush([string] $remote, [string] $branch, [bool] $withTracking)

--- a/GitHelpers.ps1
+++ b/GitHelpers.ps1
@@ -13,6 +13,8 @@
     [ ] GitCheckIn $message (check-in/push)
     [ ] GitPush - Set branch tracking or no tracking
     [ ] Integrate our GitHelpers into PowerShell commands via PowerShellGet\Install-Module Xeno-GitDevOps
+    [ ] GitMerge opt to merge unrelated histories
+        - git.exe merge --allow-unrelated-histories develop
 
   Change Log:
     2019-03-21 - 4  - Added GitPrune with sync, GitStatus, added notes
@@ -68,6 +70,11 @@ function GitMerge([string]$branch)
   Invoke-Expression "git merge ""$branch""";
 }
 
+function GitMergeUnrelated([string]$branch)
+{
+  Invoke-Expression "git merge --allow-unrelated-histories ""$branch""";
+}
+
 function GitPrune([bool] $syncPrune)
 {
   GitFetch($true);
@@ -81,7 +88,7 @@ function GitPrune([bool] $syncPrune)
     git branch -vv | sls gone `
       |% { $_.ToString().Trim() -split '\s+' | Select-Object -first 1 } `
       |% { git branch -D $_ }
-    
+
     # Alt Solutions:
     # 1. Use ``$list = git branch -a`` after a fetch with prune, and compare
     #    anything starting with "remotes/origin/" against those not starting

--- a/GitPull.ps1
+++ b/GitPull.ps1
@@ -6,6 +6,7 @@
   Usage:
     GitPull             ; Pulls current branch defaulting remote to "origin"
     GitPull "NotOrigin" ; Pulls current branch from specified remote
+    GitPull -u          ; Pull merging unrelated histories
 
   TODO:
     - Pulls branch and sets tracking so you can simply execute, ``git push`` next time
@@ -17,7 +18,9 @@
 
 # Commandline Params ---
 param(
-  [parameter(Mandatory=$false)][string] $remote = "origin"
+  [parameter(Mandatory=$false)][string] $remote = "origin",
+  [parameter(Mandatory=$false)][switch] $u = $false,
+  [Parameter(Mandatory=$false)][switch] $h = $false
   # ,[parameter(Mandatory=$false)][switch] $track = $false
 );
 
@@ -25,6 +28,18 @@ param(
 . "GitHelpers.ps1";
 
 # Our code -------------
+if ($h -eq $true)
+{
+  Write-Host "GitPull HELP";
+  Write-Host "-------------";
+  Write-Host "Pulls branch to remote repository" -ForegroundColor Yellow;
+  Write-Host "  GitPull -remote <string>  ; Pulls from specified remote (default: origin)" -ForegroundColor Yellow;
+  Write-Host "  GitPull -u                ; Pull merging unrelated histories" -ForegroundColor Yellow;
+  Write-Host "  GitPull -h                ; This help text" -ForegroundColor Yellow;
+  Write-Host "";
+  exit;
+}
+
 [string] $branchName = GitCurrentBranch;
 if ($branchName.Trim() -eq "")
 {
@@ -32,8 +47,14 @@ if ($branchName.Trim() -eq "")
   exit;
 }
 
-Write-Host "Pulling branch '${branchName}' from origin remote '${remote}'..." -ForegroundColor Green;
-GitPull($remote)($branchName);
+[string] $msg = "";
+if ($u -eq $true)
+{
+  $msg = " with unrelated history";
+}
+
+Write-Host "Pulling branch '${branchName}'${msg} from origin remote '${remote}'..." -ForegroundColor Green;
+GitPull($remote)($branchName)($u);
 
 # if ($track)
 # {

--- a/GitPush.ps1
+++ b/GitPush.ps1
@@ -28,7 +28,7 @@ param(
 # Our code -------------
 if ($h -eq $true)
 {
-  Write-Host "Git Push HELP";
+  Write-Host "GitPush HELP";
   Write-Host "-------------";
   Write-Host "Pushes branch to remote device" -ForegroundColor Yellow;
   Write-Host "  GitPush -t              Push current branch to ORIGIN and set branch tracking" -ForegroundColor Yellow;

--- a/GitSync.ps1
+++ b/GitSync.ps1
@@ -10,6 +10,7 @@
   TODO:
     - GitCheckIn $message (check-in/push)
     - Option "-track" to set tracking; don't track by default
+    - Option "-u" "-uh" to merge unrelated histories
 
   Change Log:
   2018-10-03  0.2 - Some enhancements


### PR DESCRIPTION
Related to PBI #11, create a switch GitPull to allow the merging of unrelated histories.

## Usage
``GitPull -u``

## Sample Output
```
Pulling branch 'feature/GitMergeUnrelatedHistories' with unrelated history from origin remote 'origin'...
From https://github.com/xenoinc/XenoDevOps
 * branch            feature/GitMergeUnrelatedHistories -> FETCH_HEAD
Already up to date.
```
