### PR TITLE
Merge feature/GitSyncWithBranch into develop

### DIFF
--- a/GitSync.ps1
+++ b/GitSync.ps1
@@ -19,7 +19,9 @@
 
 # Commandline Params ---
 param(
-  [parameter(Mandatory=$false)][switch] $push = $false
+  [parameter(Mandatory=$false)][switch] $push = $false,
+  [parameter(Mandatory=$false)][string] $syncBranch = "develop",
+  [parameter(Mandatory=$false)][string] $remote = "origin"
 );
 
 # Clear out cache of previous PowerShell sessions
@@ -44,11 +46,21 @@ if ($branch -eq "")
   exit;
 }
 
-GitCheckout("develop");
-GitPull;
+$syncBranch = "develop";
+
+Write-Host "Switching to ${syncBranch}..." -ForegroundColor Yellow;
+GitCheckout($syncBranch);
+
+Write-Host "Pulling latest..." -ForegroundColor Yellow;
+GitPull($remote)($syncBranch);
+
+Write-Host "Switching back to ${branch}..." -ForegroundColor Yellow;
 GitCheckout($branch);
-GitMerge("develop");
-Write-Host "Sync complete!" -ForegroundColor Green;
+
+Write-Host "Merging branches..." -ForegroundColor Yellow;
+GitMerge($syncBranch);
+
+Write-Host "Sync with '${syncBranch}' complete!" -ForegroundColor Green;
 
 # Automatically PUSH branch upstream via "-push" switch
 if ($push)


### PR DESCRIPTION
This feature adds the ability to selectively choose which branch and/or remote to sync with yours, keeping ``develop`` as the default. Related to PBI #19

This also addresses the edge-case if your (default) ``develop`` branch is not marked for tracking against remote. Now it automatically uses ``origin`` as the tracking remote for your default ``develop`` branch.

## Use Case Examples
Use wants to sync their current branch with...

### The (default) ``develop`` branch
```powershell
[feature/MyBranch]> GitSync
```

### Sync with ``develop`` and push
```powershell
[feature/MyBranch]> GitSync -p
```

### Another branch in the same repository
Merge strategy: ``feature/MyBranch`` << ``feature/TeammateBranch``

```powershell
[feature/MyBranch]> GitSync -syncBranch "feature/TeammateBranch"
```

### Sync Across Remotes
Let's say your friend's branch is on GitLab but not GitHub and you need it merged into yours.

```powershell
[feature/MyBranch]> GitSync -remote "gitlab" - syncBranch "feature/FriendsBranch"
```

Boom!  Synced ;)
