### PR TITLE
Merge feature/QuickerGitSync into develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 
 # Local only
 ud-local.bat
+sandbox/FixTools.bat
+sandbox/_BuildToolsFixed.zip

--- a/GitSync.ps1
+++ b/GitSync.ps1
@@ -46,21 +46,31 @@ if ($branch -eq "")
   exit;
 }
 
-$syncBranch = "develop";
+# $syncBranch = "develop";
+$betaTest = true;
 
-Write-Host "Switching to ${syncBranch}..." -ForegroundColor Yellow;
-GitCheckout($syncBranch);
+if ($betaTest)
+{
+  Invoke-Expression "git fetch";
+  Invoke-Expression "git fetch origin ${syncBranch}:${syncBranch}";
+  Invoke-Expression "git merge ${syncBranch}";
+}
+else
+{
+  Write-Host "Switching to ${syncBranch}..." -ForegroundColor Yellow;
+  GitCheckout($syncBranch);
 
-Write-Host "Pulling latest..." -ForegroundColor Yellow;
-GitPull($remote)($syncBranch);
+  Write-Host "Pulling latest..." -ForegroundColor Yellow;
+  GitPull($remote)($syncBranch);
 
-Write-Host "Switching back to ${branch}..." -ForegroundColor Yellow;
-GitCheckout($branch);
+  Write-Host "Switching back to ${branch}..." -ForegroundColor Yellow;
+  GitCheckout($branch);
 
-Write-Host "Merging branches..." -ForegroundColor Yellow;
-GitMerge($syncBranch);
+  Write-Host "Merging branches..." -ForegroundColor Yellow;
+  GitMerge($syncBranch);
 
-Write-Host "Sync with '${syncBranch}' complete!" -ForegroundColor Green;
+  Write-Host "Sync with '${syncBranch}' complete!" -ForegroundColor Green;
+}
 
 # Automatically PUSH branch upstream via "-push" switch
 if ($push)


### PR DESCRIPTION
Reduces `GitSync` operation time by A LOT and reduces the number of the output lines.

The following example shows early beta testing to reduce times from 41.1 sec to 11.5 sec.

## After
```
C:\dev\XXX.Control [feature-EHM-Designs]> gitsync -betaTest $true
------------------------------
Syncing 'feature-EHM-Designs' with 'develop' branch...
Fetching latest branch, develop...
Merging 'develop' with 'feature-EHM-Designs'...
Already up to date.
Sync with 'develop' complete!
Elapsed Time:  00:00:11.5146457
```

## Before
```
C:\dev\XXX.Control [feature-EHM-Designs]> gitsync -betaTest $false
------------------------------
Syncing 'feature-EHM-Designs' with 'develop' branch...
Switching to develop...
Updating files: 100% (6/6), done.
Switched to branch 'develop'
Your branch is up to date with 'origin/develop'.
Pulling latest...
From http://AAAAA:8080/tfs/BBBBB/CCCC/_git/DDDD
 * branch                develop    -> FETCH_HEAD
 = [up to date]          develop    -> origin/develop
Already up to date.
Switching back to feature-EHM-Designs...
Updating files: 100% (6/6), done.
Switched to branch 'feature-EHM-Designs'
Merging branches...
Already up to date.
```