### PR TITLE
EditorConfig includes styling settings for indentation preferences, n…

### DIFF
--- a/common/EditorConfig/.editorconfig
+++ b/common/EditorConfig/.editorconfig
@@ -1,10 +1,11 @@
-# Copyright Xeno Innovations, Inc.
+# Copyright 2021 Xeno Innovations, Inc.
 #
 # EditorConfig (http://EditorConfig.org)
 # This file provides formatting rules for the project so you can
 # keep your own personal defaults for others
 #
 # Revision Log
+# 5   2021-08-26 - C# StyleCop rules
 # 4a  2021-01-17 - C# StyleCop rules
 # 4   2020-05-10 - C# coding standards
 # 3c  2020-04-18 - Split file filters into their own sections
@@ -33,16 +34,24 @@ trim_trailing_whitespace = true
 
 # C# Coding Conventions
 
-## Switch case statements
-csharp_indent_switch_labels = true
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
 csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
 
 ## Formatting - new line options
+### Require braces to be on a new line for (also known as "Allman" style)
+###   accessors, methods, object_collection, control_blocks, types, properties, lambdas
+csharp_new_line_before_open_brace = all
 csharp_new_line_before_catch = true
 csharp_new_line_before_else = true
-### Require braces to be on a new line for (also known as "Allman" style)
-csharp_new_line_before_open_brace = accessors, methods, object_collection, control_blocks, types, properties, lambdas
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
 
 ## Spaces
 csharp_space_after_cast = false
@@ -66,39 +75,64 @@ csharp_space_after_cast = false
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 
-## Naming Conventions
+dotnet_style_allow_multiple_blank_lines_experimental = false
+dotnet_style_allow_statement_immediately_after_block_experimental = false
 
 ### Alt to LicenseHeader extension
-# file_header_template = Copyright Xeno Innovations, Inc. 2020
+# file_header_template = Copyright Xeno Innovations, Inc. 2021
 
-### Async methods should have "Async" suffix
+## Naming Conventions
+### Async methods must use "Async" suffix
 dotnet_naming_rule.async_methods_end_in_async.symbols = any_async_methods
 dotnet_naming_rule.async_methods_end_in_async.style = end_in_async
 dotnet_naming_rule.async_methods_end_in_async.severity = error
-# dotnet_naming_rule.async_methods_end_in_async.severity = suggestion
-
 dotnet_naming_symbols.any_async_methods.applicable_kinds = method
 dotnet_naming_symbols.any_async_methods.applicable_accessibilities = *
 dotnet_naming_symbols.any_async_methods.required_modifiers = async
-
 dotnet_naming_style.end_in_async.capitalization = pascal_case
 dotnet_naming_style.end_in_async.required_prefix =
 dotnet_naming_style.end_in_async.required_suffix = Async
 dotnet_naming_style.end_in_async.word_separator =
 
-### Interfaces
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+### private fields should use prefix with an underscore
+dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
+dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
+dotnet_naming_rule.private_members_with_underscore.severity = warning
+dotnet_naming_symbols.private_fields.applicable_kinds       = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
 
+### Constant fields must use PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = error
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+### Interfaces must have an I suffix
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.interface.required_modifiers =
-
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator =
+
+
+# Code analysis rules
+# IDE0058: Expression value is never used
+dotnet_diagnostic.IDE0058.severity = none
+# IDEOOO8: Use of var
+dotnet_diagnostic.IDE0008.severity = none
+# IDE0046: Convert to conditional expression
+dotnet_diagnostic.IDE0046.severity = none
+# IDE0010: Add missing cases
+dotnet_diagnostic.IDE0010.severity = none
 
 # StyleCop.Analyzers
 ## CA1031: Do not catch general exception types
@@ -106,6 +140,30 @@ dotnet_diagnostic.CA1031.severity = none
 
 # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.CS1591.severity = silent
+
+dotnet_diagnostic.SA1101.severity = silent
+dotnet_diagnostic.SA1200.severity = silent
+dotnet_diagnostic.SA1309.severity = none
+dotnet_diagnostic.SA1503.severity = silent
+dotnet_diagnostic.SA1633.severity = silent
+
+# SA1201: Elements should appear in the correct order
+dotnet_diagnostic.SA1201.severity = error
+
+# SA1503: Braces should not be omitted
+dotnet_diagnostic.SA1503.severity = none
+
+# SA1507: Code should not contain multiple blank lines in a row
+dotnet_diagnostic.SA1507.severity = error
+
+# SA1516: Elements should be separated by blank line
+dotnet_diagnostic.SA1516.severity = error
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
+# Default severity for analyzer diagnostics with category 'StyleCop.CSharp.SpacingRules'
+dotnet_analyzer_diagnostic.category-StyleCop.CSharp.SpacingRules.severity = error
 
 [*.{c,cpp,h}]
 indent_style = space
@@ -117,7 +175,7 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 
-[*.{xml,xaml,axml}]
+[*.{xml,xaml,axml,axaml}]
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true

--- a/sandbox/.editorconfig
+++ b/sandbox/.editorconfig
@@ -150,15 +150,20 @@ dotnet_diagnostic.SA1633.severity = silent
 # SA1201: Elements should appear in the correct order
 dotnet_diagnostic.SA1201.severity = error
 
-# SA1600: Elements should be documented
-dotnet_diagnostic.SA1600.severity = none
+# SA1503: Braces should not be omitted
+dotnet_diagnostic.SA1503.severity = none
 
 # SA1507: Code should not contain multiple blank lines in a row
 dotnet_diagnostic.SA1507.severity = error
 
+# SA1516: Elements should be separated by blank line
+dotnet_diagnostic.SA1516.severity = error
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
 # Default severity for analyzer diagnostics with category 'StyleCop.CSharp.SpacingRules'
 dotnet_analyzer_diagnostic.category-StyleCop.CSharp.SpacingRules.severity = error
-
 
 [*.{c,cpp,h}]
 indent_style = space
@@ -206,12 +211,3 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
-
-# SA1503: Braces should not be omitted
-dotnet_diagnostic.SA1503.severity = none
-
-# SA1201: Elements should appear in the correct order
-dotnet_diagnostic.SA1201.severity = error
-
-# SA1516: Elements should be separated by blank line
-dotnet_diagnostic.SA1516.severity = error


### PR DESCRIPTION
EditorConfig includes styling settings for:
* Indentation preferences
* New lines
* Private files `_` prefix (warning)
* Constants must be PascalCase (error)
* Interfaces must start with `I` (error)
* Also includes additional StyleCop rules to ensure formatting